### PR TITLE
removed unnecessary escaping of logo

### DIFF
--- a/app/templates/partials/prototype-header.html
+++ b/app/templates/partials/prototype-header.html
@@ -2,7 +2,7 @@
   <div id="client-id">
     {{#if options.grunt.userConfig.prototype.logo}}
       <div class="client-logo">
-        <img src="{{image-url 'options.grunt.userConfig.prototype.logo'}}" alt="{{options.grunt.userConfig.client.name}} Logo">
+        <img src="{{image-url options.grunt.userConfig.prototype.logo}}" alt="{{options.grunt.userConfig.client.name}} Logo">
       </div>
     {{else}}
       <h1 class="client-name">{{options.grunt.userConfig.client.name}}</h1>


### PR DESCRIPTION
removed quotes from `options.grunt.userConfig.prototype.logo` 
