### PR TITLE
Update Prism bower component branch

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -5,7 +5,7 @@
     "formalize": "git://github.com/nathansmith/formalize",
     "modernizr": "~2.6.2",
     "jquery": "~2.0.0",
-    "prism": "latest",
+    "prism": "gh-pages",
     "Element.details": "termi/Element.details"
   },
   "devDependencies": {}


### PR DESCRIPTION
The previous branch no longer exists and is causing bower install to fail. Fixes #15 and some of #11
