### PR TITLE
according to https://github.com/Team-Sass/color-schemer/blob/master/styl...

### DIFF
--- a/app/templates/sass/global/variables/_colors.scss
+++ b/app/templates/sass/global/variables/_colors.scss
@@ -15,8 +15,8 @@ $cs-primary: #fdb252;
 // Primary color, can be any color you can use in CSS, plus CMYK from Color Schemer
 $cs-scheme:             accented-analogic;
 // Options: mono, complement, triad, tetrad, analogic, accented-analogic
-$cs-hue-offset:         42;
-// Options: 0-100;
+$cs-hue-offset:         45deg;
+// Options: 0-90deg;
 $cs-brightness-offset:  10;
 // Options: 0-100;
 $cs-color-model:        ryb;


### PR DESCRIPTION
According to https://github.com/Team-Sass/color-schemer/blob/master/stylesheets/color-schemer/_color-schemer.scss $cs-hue-offset is used in adjust-hue(), which accepts degrees as 2nd parameter (refer to http://sass-lang.com/documentation/Sass/Script/Functions.html#adjust_hue-instance_method)
