### PR TITLE
fixes #39

### DIFF
--- a/app/templates/_gruntfile.js
+++ b/app/templates/_gruntfile.js
@@ -78,6 +78,11 @@ module.exports = function (grunt) {
   var remoteHost = os.networkInterfaces();
   for (var dev in remoteHost) {
     var alias = 0;
+
+    if (remoteHost[dev] === undefined) {
+      continue;
+    }
+
     remoteHost[dev].forEach(function (details) {
       if (details.family=='IPv4') {
         if (dev === 'en0') {


### PR DESCRIPTION
Freshly installing yo, grunt and bower.

Running yo style-prototype
answering the Qs going into the new directory and typing:

$ grunt server

Leads to the following error

Loading "Gruntfile.js" tasks...ERROR

TypeError: Cannot call method 'forEach' of undefined
Warning: Task "server" not found. Use --force to continue.
Aborted due to warnings.

The only 'strange' thing about my setup maybe that I'm using OS X Mavericks.
