### PR TITLE
changed order of sass import statements

### DIFF
--- a/app/templates/sass/global/variables/_all.scss
+++ b/app/templates/sass/global/variables/_all.scss
@@ -1,3 +1,3 @@
 @import "colors";
-@import "typography";
 @import "settings";
+@import "typography";


### PR DESCRIPTION
fixes (Line 20 of sass/global/variables/_typography.scss: Undefined variable: "$base-size".)

fixes
https://github.com/Team-Sass/generator-style-prototype/issues/49

by importing _typography.scss after _variables.scss
