### PR TITLE
update execSync to sync-exec for node 0.12+

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "chalk": "^0.4.0",
     "dateformat": "^1.0.8-1.2.3",
-    "execSync": "~1.0.1-pre",
+    "sync-exec": "~0.5",
     "fs-extra": "^0.8.1",
     "gulp-util": "^2.2.20",
     "inquirer": "^0.4.1",


### PR DESCRIPTION
According to this issue: https://github.com/mgutz/execSync/issues/38 - node 0.12+ is not working with execSync. Since an update cannot be pushed because of the camel cased name, a new version of was created here: https://www.npmjs.com/package/sync-exec

I've updated the package.json to reference this new version as I was unable to generate using Yeoman because of this issue.

Hope this is helpful!
