### PR TITLE
remove execsync as dependency and use native child_process calls in…

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -4,8 +4,9 @@ var path = require('path');
 var yeoman = require('yeoman-generator');
 var chalk = require('chalk');
 var _s = require('underscore.string');
-var sh = require('execSync');
 var shared = require('../shared.js');
+var run = require('child_process').exec;
+
 
 var SPGenerator = yeoman.generators.Base.extend({
   init: function () {
@@ -21,7 +22,8 @@ var SPGenerator = yeoman.generators.Base.extend({
       // Install dependencies unless --skip-install is passed
       //////////////////////////////
       if (!this.options['skip-install']) {
-        sh.run('bundle install --path vendor');
+        run('bundle install --path vendor')
+              
         this.installDependencies({
           callback: function () {
             console.log('\u001b[2J\u001b[0;0H');
@@ -36,8 +38,7 @@ var SPGenerator = yeoman.generators.Base.extend({
       // If the --git flag is passed, initialize git and add for initial commit
       //////////////////////////////
       if (this.options['git']) {
-        sh.run('git init');
-        sh.run('git add . && git commit -m "Style Prototype Generation"');
+        run('git init && git add . && git commit -m "Style Prototype Generation"');
       }
     });
   },

--- a/app/templates/_package-dev.json
+++ b/app/templates/_package-dev.json
@@ -8,6 +8,6 @@
     "browser-sync": "^1.3.2"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "chalk": "^0.4.0",
     "dateformat": "^1.0.8-1.2.3",
-    "execSync": "~1.0.1-pre",
     "fs-extra": "^0.8.1",
     "gulp-util": "^2.2.20",
     "inquirer": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "yeoman-generator": "^0.16.0"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.12.0"
   },
   "licenses": [
     {


### PR DESCRIPTION
 I ran into some problems running this on node 0.12 and figured it was an execsync problem. 

I've replaced all the execsync calls with native child_process calls. 

Caveats:

If you want to maintain backwards compatibility, you may want to do node version detection and set the correct functions there. This was just to get it working for the latest node version (which I think is pretty important for new users)
